### PR TITLE
Compatibility/Gtk: add FontNamedSizeService gtk

### DIFF
--- a/src/Controls/src/Core/Compatibility/Gtk/FontNamedSizeService.cs
+++ b/src/Controls/src/Core/Compatibility/Gtk/FontNamedSizeService.cs
@@ -1,0 +1,42 @@
+using System;
+using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Controls.Platform;
+
+#pragma warning disable CS0612 // Type or member is obsolete
+[assembly: Microsoft.Maui.Controls.Dependency(typeof(Microsoft.Maui.Controls.Compatibility.Platform.Gtk.FontNamedSizeService))]
+// Type or member is obsolete
+
+namespace Microsoft.Maui.Controls.Compatibility.Platform.Gtk
+{
+	public class FontNamedSizeService : IFontNamedSizeService
+	{
+		public double GetNamedSize(NamedSize size, Type targetElementType, bool useOldSizes)
+		{
+			switch (size)
+			{
+				case NamedSize.Default:
+					return 11;
+				case NamedSize.Micro:
+				case NamedSize.Caption:
+					return 12;
+				case NamedSize.Medium:
+					return 17;
+				case NamedSize.Large:
+					return 22;
+				case NamedSize.Small:
+				case NamedSize.Body:
+					return 14;
+				case NamedSize.Header:
+					return 46;
+				case NamedSize.Subtitle:
+					return 20;
+				case NamedSize.Title:
+					return 24;
+				default:
+					throw new ArgumentOutOfRangeException(nameof(size));
+			}
+		}
+	}
+}
+
+#pragma warning restore CS0612 

--- a/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
@@ -23,6 +23,9 @@ using Microsoft.Maui.Controls.Handlers.Compatibility;
 #elif TIZEN
 using Microsoft.Maui.Controls.Handlers.Compatibility;
 using Microsoft.Maui.Controls.Compatibility.Platform.Tizen;
+#elif GTK
+using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Controls.Compatibility.Platform.Gtk;
 #endif
 
 namespace Microsoft.Maui.Controls.Hosting
@@ -161,6 +164,10 @@ namespace Microsoft.Maui.Controls.Hosting
 			DependencyService.Register<ResourcesProvider>();
 			DependencyService.Register<FontNamedSizeService>();
 #pragma warning restore CS0612, CA1416 // Type or member is obsolete
+#endif
+
+#if GTK
+			DependencyService.Register<FontNamedSizeService>();
 #endif
 
 			builder.ConfigureImageSourceHandlers();


### PR DESCRIPTION
FontNamedSizeService is needed when using `Fontsize=Large` or `Fontsize=Small` in Xaml files. Without this service, we get runtime errors when trying to parse Xaml files that have Fontsize attribute in them.