### PR TITLE
Platform/Gtk: set MainWindow for size

### DIFF
--- a/src/Core/src/Platform/Gtk/ApplicationExtensions.cs
+++ b/src/Core/src/Platform/Gtk/ApplicationExtensions.cs
@@ -16,6 +16,7 @@ public static class ApplicationExtensions
 
 		var mainWindow = new MauiGtkMainWindow();
 		platformApplication.AddWindow(mainWindow);
+		MauiGtkApplication.Current.MainWindow = mainWindow;
 
 		var mauiContext = applicationContext!.MakeWindowScope(mainWindow, out var windowScope);
 

--- a/src/Core/src/Platform/Gtk/MauiGtkApplication.cs
+++ b/src/Core/src/Platform/Gtk/MauiGtkApplication.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Maui
 
 		public static MauiGtkApplication Current { get; internal set; } = null!;
 
-		public MauiGtkMainWindow MainWindow { get; protected set; } = null!;
+		public MauiGtkMainWindow MainWindow { get; internal set; } = null!; // set is not protected because it needs to be accessed from ApplicationExtensions.cs
 
 		public IServiceProvider Services { get; protected set; } = null!;
 


### PR DESCRIPTION
These changes are necessary for having access to MainWindow in MauiGtkApplication. Initially, this field was always null and was never set. We needed access to MainWindow to do manual operations like resize on it because the applications might want to specify custom size of the window.