### PR TITLE
Platform/Gtk: several fixes in layouts

### DIFF
--- a/src/Core/src/Handlers/Layout/LayoutHandler.Gtk.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.Gtk.cs
@@ -124,9 +124,21 @@ namespace Microsoft.Maui.Handlers
 
 #endif
 
+		private void UpdateVisibility(Visibility visibility)
+		{
+			if (visibility == Visibility.Visible)
+				PlatformView.Show();
+			else
+				PlatformView.Hide();
+		}
+
 		[MissingMapper]
 		public void UpdateZIndex(IView view) => throw new NotImplementedException();
 
+		static void MapVisibility(ILayoutHandler handler, ILayout layout)
+		{
+			((LayoutHandler)handler).UpdateVisibility(layout.Visibility);
+		}
 	}
 
 }

--- a/src/Core/src/Handlers/Layout/LayoutHandler.cs
+++ b/src/Core/src/Handlers/Layout/LayoutHandler.cs
@@ -24,6 +24,9 @@ namespace Microsoft.Maui.Handlers
 #if ANDROID || WINDOWS
 			[nameof(IView.InputTransparent)] = MapInputTransparent,
 #endif
+#if GTK
+			[nameof(IView.Visibility)] = MapVisibility,
+#endif
 		};
 
 		public static CommandMapper<ILayout, ILayoutHandler> CommandMapper = new(ViewCommandMapper)

--- a/src/Core/src/Platform/Gtk/LayoutView.cs
+++ b/src/Core/src/Platform/Gtk/LayoutView.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using Gtk;
 using Microsoft.Maui.Graphics.Platform.Gtk;
+using Microsoft.Maui.Primitives;
 using Rectangle = Microsoft.Maui.Graphics.Rect;
 using Size = Microsoft.Maui.Graphics.Size;
 using Point = Microsoft.Maui.Graphics.Point;
@@ -232,6 +233,25 @@ namespace Microsoft.Maui.Platform
 
 				if (RestrictToMesuredAllocation)
 					mAllocation.Size = mesuredAllocation;
+
+				// Adjust for VerticalOptions
+				if (VirtualView.VerticalLayoutAlignment == LayoutAlignment.Center)
+				{
+					mAllocation.Top += (allocation.Height - mesuredAllocation.Height) / 2.0;
+				}
+				else if (VirtualView.VerticalLayoutAlignment == LayoutAlignment.End)
+				{
+					mAllocation.Top += (allocation.Height - mesuredAllocation.Height);
+				}
+				// Adjust for HorizontalOptions
+				if (VirtualView.HorizontalLayoutAlignment == LayoutAlignment.Center)
+				{
+					mAllocation.Left += (allocation.Width - mesuredAllocation.Width) / 2.0;
+				}
+				else if (VirtualView.VerticalLayoutAlignment == LayoutAlignment.End)
+				{
+					mAllocation.Left += (allocation.Width - mesuredAllocation.Width);
+				}
 
 				ArrangeAllocation(new Rectangle(Point.Zero, mAllocation.Size));
 				AllocateChildren(mAllocation);

--- a/src/Core/src/Platform/Gtk/LayoutView.cs
+++ b/src/Core/src/Platform/Gtk/LayoutView.cs
@@ -1,4 +1,4 @@
-﻿#define TRACE_ALLOCATION
+﻿#define TRACE_ALLOCATION_
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Core/src/Platform/Gtk/LayoutView.cs
+++ b/src/Core/src/Platform/Gtk/LayoutView.cs
@@ -302,7 +302,10 @@ namespace Microsoft.Maui.Platform
 			Size cached = Size.Zero;
 
 			bool cacheHit = CanBeCached() && MeasureCache.TryGetValue(key, out cached);
-
+// TODO: the code is commented because using cache was causing problems for Layout sizes 
+// after window looses or gains focus. Ultimately we need to figure out the problem caused
+// by caching and stop disabling it to have better performance.
+/*
 			if (cacheHit)
 			{
 #if TRACE_ALLOCATION
@@ -311,6 +314,7 @@ namespace Microsoft.Maui.Platform
 					return cached;
 
 			}
+*/
 
 			var measured = VirtualView.CrossPlatformMeasure(widthConstraint, heightConstraint);
 


### PR DESCRIPTION
1. Remove debug borders from Layouts
When TRACE_ALLOCATION constant is defined, some debug borders
with width and heights is shown for layouts. By disabling them,
the debug values are removed from the final output.

2. Workaround for layout rsize problem
Layout size is messed up after window looses or gains focus.
Which is fixed by not returning the cached value.

3. Implement visibility in layouts
Layouts in Gtk now react to change in Visibility property.

4. Use vertical/horizontal options in layouts
Take VerticalOptions and HorizontalOptions of the layout into
account when calculating layout on Gtk.
This allows to customize placement of root element of the page.
Before the root layout would behave as if both options were
set to "Start".
