### PR TITLE
Core(Gtk): fixes in UI element styles

### DIFF
--- a/src/Core/src/Platform/Gtk/GtkCssExtensions.cs
+++ b/src/Core/src/Platform/Gtk/GtkCssExtensions.cs
@@ -21,7 +21,8 @@ namespace Microsoft.Maui
 				case Gtk.ComboBox box:
 
 				default:
-					mainNode = nativeView.StyleContext.Path.ToString().Split(':')[0];
+					var pathSegments = nativeView.StyleContext.Path.ToString().Split(' ');
+					mainNode = pathSegments[pathSegments.Length - 1].Split(':')[0];
 
 					break;
 			}

--- a/src/Core/src/Platform/Gtk/WidgetColorExtensions.cs
+++ b/src/Core/src/Platform/Gtk/WidgetColorExtensions.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Maui
 			var mainNode = widget.CssMainNode();
 			if (cssFlags != null)
 				mainNode = $"{mainNode}:{cssFlags}";
-			widget.SetStyleColor(color, mainNode, "background-color");
+			widget.SetStyleColor(color, mainNode, "background");
 
 		}
 


### PR DESCRIPTION
1.  Fix setting background color for Button.
Following advice from
https://stackoverflow.com/questions/1706550/gtk-modifying-background-color-of-gtkbutton#comment115871542_41850551

2. Fix setting of style in widgets in certain cases (when widget's CSS path
contains spaces).