### PR TITLE
Core(Gtk): fixes in images

### DIFF
--- a/src/Core/src/Handlers/Image/ImageHandler.Gtk.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.Gtk.cs
@@ -40,6 +40,39 @@ namespace Microsoft.Maui.Handlers
 			PlatformView.Image = obj;
 		}
 
+		static int? Request(double viewSize) => viewSize >= 0 ? (int)Math.Round(viewSize) : null;
+		private void UpdateWidthRequest(IImage image)
+		{
+			var widthRequest = Request(image.Width * PlatformView.ScaleFactor);
+
+			if (widthRequest is not null && widthRequest != PlatformView.WidthRequest && widthRequest != PlatformView.AllocatedWidth)
+			{
+				PlatformView.ChangeWidth(widthRequest.Value);
+				PlatformView.QueueResize();
+			}
+		}
+
+		private void UpdateHeightRequest(IImage image)
+		{
+			var heightRequest = Request(image.Height * PlatformView.ScaleFactor);
+
+			if (heightRequest is not null && heightRequest != PlatformView.WidthRequest && heightRequest != PlatformView.AllocatedWidth)
+			{
+				PlatformView.ChangeHeight(heightRequest.Value);
+				PlatformView.QueueResize();
+			}
+		}
+
+		public static void MapWidthRequest(IImageHandler handler, IImage view)
+		{
+			((ImageHandler)handler).UpdateWidthRequest(view);
+		}
+
+		public static void MapHeightRequest(IImageHandler handler, IImage view)
+		{
+			((ImageHandler)handler).UpdateHeightRequest(view);
+		}
+
 	}
 
 }

--- a/src/Core/src/Handlers/Image/ImageHandler.cs
+++ b/src/Core/src/Handlers/Image/ImageHandler.cs
@@ -26,6 +26,10 @@ namespace Microsoft.Maui.Handlers
 			[nameof(IImage.Aspect)] = MapAspect,
 			[nameof(IImage.IsAnimationPlaying)] = MapIsAnimationPlaying,
 			[nameof(IImage.Source)] = MapSource,
+#if GTK
+			["WidthRequest"] = MapWidthRequest,
+			["HeightRequest"] = MapHeightRequest,
+#endif
 		};
 
 		public static CommandMapper<IImage, IImageHandler> CommandMapper = new(ViewHandler.ViewCommandMapper)

--- a/src/Core/src/Platform/Gtk/ImageView.cs
+++ b/src/Core/src/Platform/Gtk/ImageView.cs
@@ -1,3 +1,5 @@
+using Gdk;
+
 namespace Microsoft.Maui.Platform
 {
 
@@ -9,11 +11,60 @@ namespace Microsoft.Maui.Platform
 
 	public class ImageView : Gtk.Image
 	{
+		// OriginalSizeBuf is added so when we want to resize the image using Pixbuf we can access the
+		// initial Pixbuf and resize that. 
+		Pixbuf? _originalSizeBuf;
+		// Image might be null because it is possible to have a WidthRequest before Pixbuf has a value.
+		// In this case, we'll just save the value, and once Pixbuf is initialized we'll update its size
+		// to have the saved values
+		int? _lastRequestedWidth;
+		int? _lastRequestedHeight;
 
-		public Gdk.Pixbuf? Image
+		public Pixbuf? Image
 		{
 			get => Pixbuf;
-			set => Pixbuf = value;
+			set
+			{
+				_originalSizeBuf = value;
+				if (_lastRequestedHeight is not null || _lastRequestedWidth is not null)
+				{
+					Pixbuf = _originalSizeBuf?.ScaleSimple(
+						_lastRequestedWidth ?? _originalSizeBuf.Width,
+						_lastRequestedHeight ?? _originalSizeBuf.Height,
+						InterpType.Bilinear
+					);
+				}
+				else
+				{
+					Pixbuf = value;
+				}
+			}
+		}
+
+		internal void ChangeHeight(int height)
+		{
+			if (Image is null)
+			{
+				_lastRequestedHeight = height;
+			}
+			else
+			{
+				var newBuf = _originalSizeBuf?.ScaleSimple(Pixbuf.Width, height, InterpType.Bilinear);
+				Pixbuf = newBuf;
+			}
+		}
+
+		internal void ChangeWidth(int width)
+		{
+			if (Image is null)
+			{
+				_lastRequestedWidth = width;
+			}
+			else
+			{
+				var newBuf = _originalSizeBuf?.ScaleSimple(width, Pixbuf.Height, InterpType.Bilinear);
+				Pixbuf = newBuf;
+			}
 		}
 
 	}

--- a/src/Core/src/Platform/Gtk/ImageViewExtensions.cs
+++ b/src/Core/src/Platform/Gtk/ImageViewExtensions.cs
@@ -78,10 +78,6 @@ namespace Microsoft.Maui
 				// no-op
 
 			}
-#pragma warning disable CS0168
-			catch (Exception ex)
-#pragma warning restore CS0168
-			{ }
 			finally
 			{
 				// only mark as finished if we are still working on the same image

--- a/src/Core/src/Platform/Gtk/WidgetExtensions.cs
+++ b/src/Core/src/Platform/Gtk/WidgetExtensions.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Maui
 
 					break;
 				case Visibility.Collapsed:
+					nativeView.Visible = false;
 
 					break;
 				default:


### PR DESCRIPTION
1. Fix Visibility bug in WidgetExtenstion.
When visibility for image or label (or other views) was set to
false, they stayed visible in the application.

2. Fix image resize.
Implement WidthRequest and HeightRequest mappings for Image.
