### PR TITLE
Core(Gtk): fix picker

### DIFF
--- a/src/Core/src/Platform/Gtk/PickerExtensions.cs
+++ b/src/Core/src/Platform/Gtk/PickerExtensions.cs
@@ -44,12 +44,12 @@ namespace Microsoft.Maui
 			if (nativeView == null)
 				return;
 
-			if (nativeView.HasEntry)
+			if (nativeView.HasEntry && nativeView.Entry.Attributes is not null)
 			{
 				nativeView.Entry.Attributes = nativeView.Entry.Attributes.AttrListFor(spacing);
 			}
 
-			if (nativeView.GetCellRendererText() is { } cell)
+			if (nativeView.GetCellRendererText() is { } cell && cell.Attributes is not null)
 				cell.Attributes = cell.Attributes.AttrListFor(spacing);
 		}
 


### PR DESCRIPTION
1. Fix picker not setting initial value
Fix bug when initial value of picker would not be set
because of circular dependency between virtual view and
platform view.

2. Check if Attributes is null to avoid runtime error.