### PR TITLE
Core(Gtk): implemented navigation page and toolbar

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/Toolbar/Toolbar.Gtk.cs
+++ b/src/Controls/src/Core/HandlerImpl/Toolbar/Toolbar.Gtk.cs
@@ -1,0 +1,55 @@
+using System;
+using Microsoft.Maui.Controls.Platform;
+
+namespace Microsoft.Maui.Controls
+{
+	public partial class Toolbar
+	{
+		MauiToolbar PlatformView => Handler?.PlatformView as MauiToolbar ?? throw new InvalidOperationException("Native View not set");
+
+		[MissingMapper]
+		public static void MapBarTextColor(ToolbarHandler handler, Toolbar toolbar)
+		{
+		}
+
+		public static void MapIsVisible(ToolbarHandler handler, Toolbar toolbar)
+		{
+			handler.PlatformView?.UpdateIsVisible(toolbar);
+		}
+
+		public static void MapBackButtonVisible(ToolbarHandler handler, Toolbar toolbar)
+		{
+			handler.PlatformView?.UpdateBackButtonVisibility(toolbar);
+		}
+
+		[MissingMapper]
+		public static void MapTitleIcon(ToolbarHandler handler, Toolbar toolbar)
+		{
+		}
+
+		[MissingMapper]
+		public static void MapTitleView(ToolbarHandler handler, Toolbar toolbar)
+		{
+		}
+
+		[MissingMapper]
+		public static void MapIconColor(ToolbarHandler handler, Toolbar toolbar)
+		{
+		}
+
+		[MissingMapper]
+		public static void MapToolbarItems(ToolbarHandler handler, Toolbar toolbar)
+		{
+		}
+
+		[MissingMapper]
+		public static void MapBackButtonTitle(ToolbarHandler handler, Toolbar toolbar)
+		{
+		}
+
+		[MissingMapper]
+		public static void MapBarBackground(ToolbarHandler handler, Toolbar toolbar)
+		{
+		}
+	}
+}

--- a/src/Controls/src/Core/HandlerImpl/Toolbar/Toolbar.cs
+++ b/src/Controls/src/Core/HandlerImpl/Toolbar/Toolbar.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Maui.Controls
 		public static IPropertyMapper<Toolbar, ToolbarHandler> ControlsToolbarMapper =
 			   new PropertyMapper<Toolbar, ToolbarHandler>(ToolbarHandler.Mapper)
 			   {
-#if ANDROID || WINDOWS || TIZEN
+#if ANDROID || WINDOWS || TIZEN || GTK
 				   [nameof(IToolbar.IsVisible)] = MapIsVisible,
 				   [nameof(IToolbar.BackButtonVisible)] = MapBackButtonVisible,
 				   [nameof(Toolbar.TitleIcon)] = MapTitleIcon,

--- a/src/Controls/src/Core/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Maui.Controls
 
 		partial void Init();
 
-#if WINDOWS || ANDROID || TIZEN
+#if WINDOWS || ANDROID || TIZEN || GTK
 		const bool UseMauiHandler = true;
 #else
 		const bool UseMauiHandler = false;

--- a/src/Controls/src/Core/Platform/Gtk/Extensions/ToolbarExtensions.cs
+++ b/src/Controls/src/Core/Platform/Gtk/Extensions/ToolbarExtensions.cs
@@ -1,0 +1,15 @@
+namespace Microsoft.Maui.Controls.Platform
+{
+	internal static class ToolbarExtensions
+	{
+		public static void UpdateIsVisible(this MauiToolbar platformToolbar, Toolbar toolbar)
+		{
+			platformToolbar.Visible = toolbar.IsVisible;
+		}
+
+		public static void UpdateBackButtonVisibility(this MauiToolbar platformToolbar, Toolbar toolbar)
+		{
+			platformToolbar.BackButton.Visible = toolbar.BackButtonVisible;
+		}
+	}
+}

--- a/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Maui.Controls.Hosting
 			handlersCollection.AddHandler<ShellSection, ShellSectionHandler>();
 #endif
 #endif
-#if WINDOWS || ANDROID || TIZEN
+#if WINDOWS || ANDROID || TIZEN || GTK
 			handlersCollection.AddHandler<NavigationPage, NavigationViewHandler>();
 			handlersCollection.AddHandler<Toolbar, ToolbarHandler>();
 			handlersCollection.AddHandler<FlyoutPage, FlyoutViewHandler>();

--- a/src/Core/src/Handlers/NavigationPage/NavigationViewHandler.Gtk.cs
+++ b/src/Core/src/Handlers/NavigationPage/NavigationViewHandler.Gtk.cs
@@ -13,28 +13,28 @@ namespace Microsoft.Maui.Handlers
 
 		protected override NavigationView CreatePlatformView()
 		{
-			return new();
+			return new NavigationView();
 		}
 
 		protected override void ConnectHandler(NavigationView nativeView)
 		{
 			base.ConnectHandler(nativeView);
-
-			var virtualView = VirtualView;
-
+			nativeView.Connect(VirtualView);
 		}
 
 		protected override void DisconnectHandler(NavigationView nativeView)
 		{
 			base.DisconnectHandler(nativeView);
-
-			var virtualView = VirtualView;
-
+			nativeView.Disconnect(VirtualView);
 		}
 
-		public static void RequestNavigation(INavigationViewHandler arg1, IStackNavigation arg2, object? arg3)
+		public static void RequestNavigation(INavigationViewHandler handler, IStackNavigation navigation, object? request)
 		{
-			throw new NotImplementedException();
+			if (handler is NavigationViewHandler platformHandler && request is NavigationRequest navRequest)
+			{
+				platformHandler.PlatformView?.RequestNavigation(navRequest);
+				navigation.NavigationFinished(navRequest.NavigationStack);
+			}
 		}
 	}
 

--- a/src/Core/src/Handlers/Toolbar/IToolbarHandler.cs
+++ b/src/Core/src/Handlers/Toolbar/IToolbarHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiToolbar;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.MauiToolbar;
 #elif GTK
-using PlatformView = Gtk.Widget;
+using PlatformView = Microsoft.Maui.Platform.MauiToolbar;
 #elif (NETSTANDARD || !PLATFORM) || (NET6_0_OR_GREATER && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif

--- a/src/Core/src/Handlers/Toolbar/ToolbarHandler.Gtk.cs
+++ b/src/Core/src/Handlers/Toolbar/ToolbarHandler.Gtk.cs
@@ -2,9 +2,9 @@ using System;
 
 namespace Microsoft.Maui.Handlers
 {
-	public partial class ToolbarHandler : ElementHandler<IToolbar, Gtk.Widget>
+	public partial class ToolbarHandler : ElementHandler<IToolbar, MauiToolbar>
 	{
-		protected override Gtk.Widget CreatePlatformElement() => new NotImplementedView();
+		protected override MauiToolbar CreatePlatformElement() => new();
 
 		public static void MapTitle(IToolbarHandler arg1, IToolbar arg2)
 		{

--- a/src/Core/src/Handlers/Toolbar/ToolbarHandler.cs
+++ b/src/Core/src/Handlers/Toolbar/ToolbarHandler.cs
@@ -7,7 +7,7 @@ using PlatformView = Microsoft.Maui.Platform.MauiToolbar;
 #elif TIZEN
 using PlatformView = Microsoft.Maui.Platform.MauiToolbar;
 #elif GTK
-using PlatformView = Gtk.Widget;
+using PlatformView = Microsoft.Maui.Platform.MauiToolbar;
 #elif (NETSTANDARD || !PLATFORM) || (NET6_0_OR_GREATER && !IOS && !ANDROID && !TIZEN)
 using PlatformView = System.Object;
 #endif

--- a/src/Core/src/Handlers/View/ViewHandler.Gtk.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.Gtk.cs
@@ -40,7 +40,23 @@
 		[MissingMapper]
 		public virtual bool NeedsContainer => false;
 
+		public static void MapToolbar(IViewHandler handler, IView view)
+		{
+			if (view is IToolbarElement tb)
+				MapToolbar(handler, tb);
+		}
 
+		internal static void MapToolbar(IElementHandler handler, IToolbarElement tb)
+		{
+			if (handler.MauiContext is not null)
+			{
+				var toolbarContainer = handler.MauiContext.GetToolBarContainer();
+				if (toolbarContainer is not null)
+				{
+					toolbarContainer.SetToolbar(tb.Toolbar?.ToPlatform(handler.MauiContext) as MauiToolbar);
+				}
+			}
+		}
 	}
 
 }

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Maui.Handlers
 				[nameof(IView.AnchorY)] = MapAnchorY,
 				[nameof(IViewHandler.ContainerView)] = MapContainerView,
 				[nameof(IBorder.Border)] = MapBorderView,
-#if ANDROID || WINDOWS || TIZEN
+#if ANDROID || WINDOWS || TIZEN || GTK
 				[nameof(IToolbarElement.Toolbar)] = MapToolbar,
 #endif
 				[nameof(IView.InputTransparent)] = MapInputTransparent,

--- a/src/Core/src/Handlers/Window/WindowHandler.Gtk.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.Gtk.cs
@@ -20,6 +20,12 @@ namespace Microsoft.Maui.Handlers
 
 		[MissingMapper]
 		public static void MapRequestDisplayDensity(IWindowHandler handler, IWindow window, object? args) { }
+
+		public static void MapToolbar(IWindowHandler handler, IWindow view)
+		{
+			if (view is IToolbarElement tb)
+				ViewHandler.MapToolbar(handler, tb);
+		}
 	}
 
 }

--- a/src/Core/src/Handlers/Window/WindowHandler.cs
+++ b/src/Core/src/Handlers/Window/WindowHandler.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Maui.Handlers
 			[nameof(IWindow.MinimumWidth)] = MapMinimumWidth,
 			[nameof(IWindow.MinimumHeight)] = MapMinimumHeight,
 #endif
-#if ANDROID || WINDOWS || TIZEN
+#if ANDROID || WINDOWS || TIZEN || GTK
 			[nameof(IToolbarElement.Toolbar)] = MapToolbar,
 #endif
 #if WINDOWS || IOS

--- a/src/Core/src/Platform/Gtk/MauiContextExtensions.cs
+++ b/src/Core/src/Platform/Gtk/MauiContextExtensions.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using Gtk;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Maui.Platform;
@@ -5,7 +7,31 @@ namespace Microsoft.Maui.Platform;
 internal static partial class MauiContextExtensions
 {
 
-	public static Gtk.Window GetPlatformWindow(this IMauiContext mauiContext) =>
-		mauiContext.Services.GetRequiredService<Gtk.Window>();
+	public static Window GetPlatformWindow(this IMauiContext mauiContext) =>
+		mauiContext.Services.GetRequiredService<Window>();
+
+	public static IToolbarContainer? GetToolBarContainer(this IMauiContext mauiContext)
+	{
+		var queue = new Queue<Widget>(mauiContext.GetPlatformWindow().Children);
+		while (queue.Count != 0)
+		{
+			var curr = queue.Dequeue();
+			if (curr is IToolbarContainer result)
+			{
+				return result;
+			}
+
+			if (curr is not Container container)
+				continue;
+
+			foreach (var child in container.Children)
+			{
+				queue.Enqueue(child);
+			}
+		}
+
+		return null;
+	}
+
 
 }

--- a/src/Core/src/Platform/Gtk/MauiToolbar.cs
+++ b/src/Core/src/Platform/Gtk/MauiToolbar.cs
@@ -1,0 +1,25 @@
+using Gtk;
+
+namespace Microsoft.Maui.Platform
+{
+	public class MauiToolbar : Box
+	{
+		internal Button BackButton { get; }
+
+		public delegate void BackButtonClickedEventHandler(object? sender);
+		public event BackButtonClickedEventHandler? BackButtonClicked;
+
+		public MauiToolbar() : base(Orientation.Horizontal, 0)
+		{
+			BackButton = new Button();
+			BackButton.Image = new Image(Stock.GoBack, IconSize.Button);
+			// Remove button border
+			BackButton.Relief = ReliefStyle.None;
+
+			BackButton.Clicked += (sender, args) => BackButtonClicked?.Invoke(sender);
+
+			PackStart(BackButton, false, false, 0);
+			NoShowAll = true;
+		}
+	}
+}

--- a/src/Core/src/Platform/Gtk/NavigationView.cs
+++ b/src/Core/src/Platform/Gtk/NavigationView.cs
@@ -1,10 +1,43 @@
+using System;
+using System.Linq;
+using Gtk;
+
 namespace Microsoft.Maui.Platform
 {
 
 	public class NavigationView : Gtk.Box
 	{
-
+		Gtk.Widget? pageWidget = null;
+		IMauiContext? mauiContext = null;
+		
 		public NavigationView() : base(Gtk.Orientation.Horizontal, 0) { }
+
+		public void Connect(IStackNavigationView virtualView)
+		{
+			mauiContext = virtualView.Handler?.MauiContext;
+		}
+
+		public void Disconnect(IStackNavigationView virtualView)
+		{
+		}
+
+		public void RequestNavigation(NavigationRequest request)
+		{
+			// stack top is last
+			var page = request.NavigationStack.Last();
+			var newPageWidget = page.ToPlatform(mauiContext!);
+			if (pageWidget is null)
+			{
+				this.PackStart(newPageWidget, true, true, 0);
+			}
+			else
+			{
+				this.Remove(pageWidget);
+				this.Add(newPageWidget);
+				this.SetChildPacking(newPageWidget, true, true, 0, PackType.Start);
+			}
+			pageWidget = newPageWidget;
+		}
 
 	}
 

--- a/src/Core/src/Platform/Gtk/NavigationView.cs
+++ b/src/Core/src/Platform/Gtk/NavigationView.cs
@@ -1,42 +1,82 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Gtk;
 
 namespace Microsoft.Maui.Platform
 {
-
-	public class NavigationView : Gtk.Box
+	public interface IToolbarContainer
 	{
-		Gtk.Widget? pageWidget = null;
-		IMauiContext? mauiContext = null;
-		
-		public NavigationView() : base(Gtk.Orientation.Horizontal, 0) { }
+		public void SetToolbar(MauiToolbar? toolbar);
+	}
+	public class NavigationView : Box, IToolbarContainer
+	{
+		MauiToolbar? _toolbar;
+		Widget? _pageWidget;
+		IMauiContext? _mauiContext;
+		IStackNavigation? _virtualView;
+		IReadOnlyList<IView> _navigationStack = new List<IView>();
+
+		public NavigationView() : base(Orientation.Vertical, 0)
+		{
+
+		}
 
 		public void Connect(IStackNavigationView virtualView)
 		{
-			mauiContext = virtualView.Handler?.MauiContext;
+			_mauiContext = virtualView.Handler?.MauiContext;
+			_virtualView = virtualView;
 		}
 
 		public void Disconnect(IStackNavigationView virtualView)
 		{
+			_mauiContext = null;
+			_virtualView = null;
+		}
+
+		public void SetToolbar(MauiToolbar? toolbar)
+		{
+			if (toolbar is null)
+				return;
+
+			if (_toolbar is not null)
+			{
+				_toolbar.BackButtonClicked -= NavigateBack;
+				Remove(_toolbar);
+			}
+
+			toolbar.BackButtonClicked += NavigateBack;
+			_toolbar = toolbar;
+			PackStart(_toolbar, false, true, 0);
+		}
+
+		void NavigateBack(object? sender)
+		{
+			if (_navigationStack.Count <= 1)
+			{
+				return;
+			}
+			var request = new NavigationRequest(_navigationStack.SkipLast(1).ToList(), false);
+			_virtualView?.RequestNavigation(request);
 		}
 
 		public void RequestNavigation(NavigationRequest request)
 		{
 			// stack top is last
 			var page = request.NavigationStack.Last();
-			var newPageWidget = page.ToPlatform(mauiContext!);
-			if (pageWidget is null)
+			_navigationStack = request.NavigationStack;
+			var newPageWidget = page.ToPlatform(_mauiContext!);
+			if (_pageWidget is null)
 			{
-				this.PackStart(newPageWidget, true, true, 0);
+				PackEnd(newPageWidget, true, true, 0);
 			}
 			else
 			{
-				this.Remove(pageWidget);
-				this.Add(newPageWidget);
-				this.SetChildPacking(newPageWidget, true, true, 0, PackType.Start);
+				Remove(_pageWidget);
+				Add(newPageWidget);
+				SetChildPacking(newPageWidget, true, true, 0, PackType.End);
 			}
-			pageWidget = newPageWidget;
+			_pageWidget = newPageWidget;
 		}
 
 	}


### PR DESCRIPTION
1. Implemented NavigationViewHandler for Gtk.
Made changes so that NavigationViewHandler is used for
NavigationPage in Gtk, instead of generic Page handler.
It is incomplete at the moment.

2. Implement MauiToolbar to use in NavigationView.
Mapped properties like Visibility and Implemented BackButton
to be able to use HasNavigationBar and be able to navigate
properly between pages.