### PR TITLE
bump dependencies

### DIFF
--- a/.github/workflows/build-gtk.yml
+++ b/.github/workflows/build-gtk.yml
@@ -4,24 +4,26 @@ on: [push, pull_request]
 jobs:
   build_and_test:
     name: Build & Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       GtkSharpVersion: 3.24.24.117-develop
       GtkSharpManifestVersion: 8.0.200
       DotnetVersion: 8.0.200
     steps:
       - name: Checkout MAUI repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
       - name: Setup .NET SDK ${{ env.DotnetVersion }}
-        uses: actions/setup-dotnet@v1.7.2
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DotnetVersion }}
+
       - name: Install gtk workload
         run: |
             # For some reason automatic workload manifest detection doesn't work (see https://github.com/GtkSharp/GtkSharp/issues/355#issuecomment-1446262239), so download and uzip mainfest file manually
             dotnet nuget add source --name nuget.org "https://api.nuget.org/v3/index.json"
             wget https://www.nuget.org/api/v2/package/gtksharp.net.sdk.gtk.manifest-${{ env.GtkSharpManifestVersion }}/$GtkSharpVersion -O gtksharp.net.sdk.gtk.manifest-${{ env.GtkSharpManifestVersion }}.nupkg            
-            DOTNET_DIR=/home/runner/.dotnet
+            DOTNET_DIR=/usr/share/dotnet
             WORKLOAD_MANIFEST_DIR=$DOTNET_DIR/sdk-manifests/${{ env.DotnetVersion }}/gtksharp.net.sdk.gtk
             mkdir -p $WORKLOAD_MANIFEST_DIR
             unzip -j gtksharp.net.sdk.gtk.manifest-${{ env.GtkSharpManifestVersion }}.nupkg "data/*" -d $WORKLOAD_MANIFEST_DIR/
@@ -37,14 +39,13 @@ jobs:
 
   dotnet-format:
     needs: build_and_test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run dotnet format
         run: |
           # remark: doesnt work, alwasy fails:
           # dotnet format whitespace ./src --folder --exclude Templates/src
           git diff --exit-code
-

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,7 +6,7 @@
     <MicrosoftDotnetSdkInternalPackageVersion>8.0.100</MicrosoftDotnetSdkInternalPackageVersion>
     <!-- dotnet/runtime -->
     <MicrosoftNETCoreAppRefPackageVersion>8.0.0</MicrosoftNETCoreAppRefPackageVersion>
-    <SystemTextJsonPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextJsonPackageVersion>
+    <SystemTextJsonPackageVersion>8.0.5</SystemTextJsonPackageVersion>
     <SystemTextEncodingsWebPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemTextEncodingsWebPackageVersion>
     <MicrosoftBclAsyncInterfacesPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</MicrosoftBclAsyncInterfacesPackageVersion>
     <!-- Microsoft/Extensions -->


### PR DESCRIPTION
### Description of Change

- [build(deps): bump System.Text.Json from 8.0.0 to 8.0.5](https://github.com/jsuarezruiz/maui-linux/pull/96/commits/736ce9985e04c3b742759551bb18e179006c5cf1) ([736ce99](https://github.com/jsuarezruiz/maui-linux/pull/96/commits/736ce9985e04c3b742759551bb18e179006c5cf1))
  > System.Text.Json 8.0.0 has at two vulnerabilities with high severity.
  > Details
  > Advisory: https://github.com/advisories/GHSA-8g4q-xg66-9fp4	Severity: high
  > Advisory: https://github.com/advisories/GHSA-hh2w-p6rv-4g7w	Severity: high

- [ci: bump dependencies for github actions](https://github.com/jsuarezruiz/maui-linux/pull/96/commits/9c2cf4c3a5a730e49a0f0e3860fc79ccf0173f00) ([9c2cf4c](https://github.com/jsuarezruiz/maui-linux/pull/96/commits/9c2cf4c3a5a730e49a0f0e3860fc79ccf0173f00))
  For improving the efficiency of the ci/cd
